### PR TITLE
Switch to touch_pages from memset to reduce memory write cycles.

### DIFF
--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -148,6 +148,19 @@ static void php_sock_stream_wait_for_data(php_stream *stream, php_netstream_data
 	}
 }
 
+#ifdef __OS2__				// 2022-05-04 SHL
+/**
+ * touch buffer pages to ensure committed
+ */
+static inline void touch_pages(char* buf, int bufbytes)
+{
+        char *p = buf;
+        int cnt = 0;
+        for (; cnt < bufbytes; p += 4096, cnt += 4096)
+                *p=0; 
+}
+#endif
+
 static ssize_t php_sockop_read(php_stream *stream, char *buf, size_t count)
 {
 	php_netstream_data_t *sock = (php_netstream_data_t*)stream->abstract;
@@ -164,8 +177,8 @@ static ssize_t php_sockop_read(php_stream *stream, char *buf, size_t count)
 			return 0;
 	}
 
-#ifdef __OS2__
-	memset(buf,  0, count); // Fix issues with recv failing
+#ifdef __OS2__				// 2022-05-04 SHL switch to touch_pages for speed
+	touch_pages(buf, count); 	// Fix issues with recv failing
 #endif
 
 	nr_bytes = recv(sock->socket, buf, XP_SOCK_BUF_SIZE(count), (sock->is_blocked && sock->timeout.tv_sec != -1) ? MSG_DONTWAIT : 0);
@@ -301,8 +314,8 @@ static inline int sock_recvfrom(php_netstream_data_t *sock, char *buf, size_t bu
 			}
 		}
 	} else {
-#ifdef __OS2__
-  	memset(buf,  0, buflen); // Fix issues with recv failing
+#ifdef __OS2__				// 2022-05-04 SHL switch to touch_pages for speed
+  		touch_pages(buf,  buflen);	// Fix issues with recv failing
 #endif
 		ret = recv(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags);
 		ret = (ret == SOCK_CONN_ERR) ? -1 : ret;
@@ -350,8 +363,8 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
 #endif
 					int err;
 
-#ifdef __OS2__
-	        memset(&buf,  0, sizeof(buf)); // Fix issues with recv failing
+#ifdef __OS2__				// 2022-05-04 SHL switch to touch_pages for speed
+					touch_pages(&buf,  sizeof(buf));	// Fix issues with recv failing
 #endif
 					ret = recv(sock->socket, &buf, sizeof(buf), MSG_PEEK);
 					err = php_socket_errno();


### PR DESCRIPTION
This will reduce the memory accesses to 2 from 8192 when committed the large receive buffers.